### PR TITLE
Upstream updates to the service bundler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <cassandra.test.version>3.11.3</cassandra.test.version>
     <cassandra.driver.version>3.7.0</cassandra.driver.version>
-    <jena.version>3.11.0</jena.version>
+    <jena.version>3.12.0</jena.version>
     <commons.rdf.version>0.5.0</commons.rdf.version>
     <thorntail.version>2.4.0.Final</thorntail.version>
     <tamaya.version>0.4-incubating-SNAPSHOT</tamaya.version>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -56,12 +56,6 @@
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-http</artifactId>
       <version>${trellis.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.tamaya</groupId>
-          <artifactId>tamaya-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.trellisldp</groupId>
@@ -70,25 +64,8 @@
     </dependency>
     <dependency>
       <groupId>org.trellisldp</groupId>
-      <artifactId>trellis-rdfa</artifactId>
-      <version>${trellis.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.tamaya</groupId>
-          <artifactId>tamaya-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.trellisldp</groupId>
       <artifactId>trellis-io-jena</artifactId>
       <version>${trellis.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.tamaya</groupId>
-          <artifactId>tamaya-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.trellisldp</groupId>
@@ -104,12 +81,6 @@
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-webac</artifactId>
       <version>${trellis.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.tamaya</groupId>
-          <artifactId>tamaya-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
   <!-- Configuration -->

--- a/webapp/src/main/java/edu/si/trellis/CassandraServiceBundler.java
+++ b/webapp/src/main/java/edu/si/trellis/CassandraServiceBundler.java
@@ -1,20 +1,16 @@
 package edu.si.trellis;
 
-import static java.util.Collections.singletonList;
-
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
 import org.trellisldp.api.*;
-import org.trellisldp.constraint.LdpConstraints;
 import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.ServiceBundler;
 import org.trellisldp.http.core.TimemapGenerator;
 import org.trellisldp.io.JenaIOService;
-
-import java.util.List;
 
 /**
  * Use to supply injected components for a Trellis application.
@@ -41,11 +37,16 @@ public class CassandraServiceBundler implements ServiceBundler {
     @Inject
     private NamespaceService namespaceService;
 
+    @Inject
+    private Instance<ConstraintService> constraintServices;
+
     private TimemapGenerator timemapGenerator = new TimemapGenerator() { };
 
     private EtagGenerator etagGenerator = new EtagGenerator() { };
 
-    private List<ConstraintService> constraintServices = singletonList(new LdpConstraints());
+    @Produces
+    @ApplicationScoped
+    private IdentifierService idService = new DefaultIdentifierService();
 
     @Produces
     @ApplicationScoped


### PR DESCRIPTION
Related to trellis-ldp/trellis#441
Related to trellis-ldp/trellis#430
Depends on trellis-ldp/trellis#448

Additionally, this updates Jena to the latest release, bringing this
code into alingment with the Trellis Jena dependency.

This also removes some unnecessary Tamaya exclusions.